### PR TITLE
Fix Vercel build detection by adding root package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aero-crm",
+  "private": true,
+  "scripts": {
+    "dev": "npm run dev --prefix diagrams-app",
+    "build": "npm run build --prefix diagrams-app",
+    "start": "npm run start --prefix diagrams-app",
+    "lint": "npm run lint --prefix diagrams-app"
+  },
+  "dependencies": {
+    "next": "15.5.4",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "cd diagrams-app && npm install",
-  "buildCommand": "cd diagrams-app && npm run build",
-  "devCommand": "cd diagrams-app && npm run dev"
+  "installCommand": "npm install --prefix diagrams-app",
+  "buildCommand": "npm run build --prefix diagrams-app",
+  "devCommand": "npm run dev --prefix diagrams-app"
 }


### PR DESCRIPTION
## Summary
- add a root-level package.json so Vercel can detect the Next.js dependency during framework detection
- proxy dev/build scripts to the diagrams-app workspace using npm --prefix commands
- update Vercel commands to reuse the centralized scripts

