### PR TITLE
Fix diagram model typings for Next.js build

### DIFF
--- a/components/diagrams/architecture-diagram.tsx
+++ b/components/diagrams/architecture-diagram.tsx
@@ -3,12 +3,14 @@
 import { useCallback } from "react";
 import { DiagramModel, DefaultLinkModel, type DiagramEngine } from "@projectstorm/react-diagrams";
 import { NodeModel, PortModel, PortModelAlignment, PortWidget } from "@projectstorm/react-diagrams-core";
+import type { BasePositionModelOptions } from "@projectstorm/react-canvas-core";
 import type { NodeModelGenerics } from "@projectstorm/react-diagrams-core/dist/@types/entities/node/NodeModel";
 import { DefaultPortModel } from "@projectstorm/react-diagrams-defaults";
 import { DiagramViewport } from "@/components/diagram-viewport";
 import { useDiagramEngine } from "@/lib/diagram/use-diagram-engine";
 import { AbstractReactFactory } from "@projectstorm/react-canvas-core";
 import type { DefaultPortModelOptions } from "@projectstorm/react-diagrams-defaults";
+import { Point } from "@projectstorm/geometry";
 
 const palette = {
   client: { base: "#0a1929", accent: "#38bdf8" },
@@ -47,7 +49,11 @@ type ArchitectureNodeGenerics = NodeModelGenerics & {
 
 class ArchitectureNodeModel extends NodeModel<ArchitectureNodeGenerics> {
   constructor(options: ArchitectureNodeOptions) {
-    super({ type: "architecture-node" });
+    const positionPoint = new Point(options.position.x, options.position.y);
+    super({
+      type: "architecture-node",
+      position: positionPoint,
+    } as BasePositionModelOptions & ArchitectureNodeOptions);
     this.options = {
       ...this.options,
       name: options.name,
@@ -198,7 +204,6 @@ function connect(from: ArchitectureNodeModel, to: ArchitectureNodeModel, options
   link.setWidth(lineWidth);
   link.getOptions().curvyness = curvyness ?? 32;
   link.getOptions().selectedColor = strokeColor;
-  link.getOptions().selectedWidth = lineWidth + 0.6;
   if (label) {
     link.addLabel(label);
   }

--- a/components/diagrams/bpmn-diagram.tsx
+++ b/components/diagrams/bpmn-diagram.tsx
@@ -263,7 +263,6 @@ function stylizeLink(link: DefaultLinkModel, label?: string, color = palette.hig
   link.setWidth(2.6);
   link.getOptions().curvyness = 35;
   link.getOptions().selectedColor = color;
-  link.getOptions().selectedWidth = 3;
   if (label) {
     link.addLabel(label);
   }

--- a/components/diagrams/journey-diagram.tsx
+++ b/components/diagrams/journey-diagram.tsx
@@ -257,7 +257,6 @@ function connectLink(
   link.setWidth(width);
   link.getOptions().curvyness = definition.curvyness ?? defaults.curvyness;
   link.getOptions().selectedColor = accent;
-  link.getOptions().selectedWidth = width + 0.6;
   if (definition.label) {
     link.addLabel(definition.label);
   }

--- a/components/diagrams/uml-diagram.tsx
+++ b/components/diagrams/uml-diagram.tsx
@@ -3,12 +3,14 @@
 import { useCallback } from "react";
 import { DiagramModel, DefaultLinkModel, type DiagramEngine } from "@projectstorm/react-diagrams";
 import { AbstractReactFactory } from "@projectstorm/react-canvas-core";
+import type { BasePositionModelOptions } from "@projectstorm/react-canvas-core";
 import { DiagramViewport } from "@/components/diagram-viewport";
 import { useDiagramEngine } from "@/lib/diagram/use-diagram-engine";
 import type { NodeModelGenerics } from "@projectstorm/react-diagrams-core/dist/@types/entities/node/NodeModel";
 import { NodeModel, PortModel, PortModelAlignment, PortWidget } from "@projectstorm/react-diagrams-core";
 import { DefaultPortModel } from "@projectstorm/react-diagrams-defaults";
 import type { DefaultPortModelOptions } from "@projectstorm/react-diagrams-defaults";
+import { Point } from "@projectstorm/geometry";
 
 interface ClassOptions {
   name: string;
@@ -20,8 +22,8 @@ interface ClassOptions {
 
 type ClassConfig = ClassOptions & { type?: string };
 
-type ClassNodeGenerics = NodeModelGenerics & {
-  OPTIONS: ClassConfig;
+type ClassNodeGenerics = Omit<NodeModelGenerics, "OPTIONS"> & {
+  OPTIONS: BasePositionModelOptions & ClassConfig;
 };
 
 const palette = {
@@ -45,7 +47,11 @@ function withAlpha(hex: string, alpha: number) {
 
 class ClassNodeModel extends NodeModel<ClassNodeGenerics> {
   constructor(options: ClassOptions) {
-    super({ type: "class-node" });
+    const positionPoint = new Point(options.position.x, options.position.y);
+    super({
+      type: "class-node",
+      position: positionPoint,
+    } as BasePositionModelOptions & ClassConfig);
 
     this.options = {
       ...this.options,
@@ -306,8 +312,6 @@ export function UmlDiagram() {
       link.setWidth(lineWidth);
       link.getOptions().curvyness = style.curvyness ?? 14;
       link.getOptions().selectedColor = accent;
-      link.getOptions().selectedWidth = lineWidth + 0.6;
-      link.getOptions().hoverWidth = lineWidth + 0.4;
       link.addLabel(labelFrom);
       link.addLabel(labelTo);
       if (note) {


### PR DESCRIPTION
## Summary
- align architecture and UML diagram node constructors with BasePositionModelOptions using Point instances
- remove references to unsupported DefaultLinkModel option fields across diagram helpers

## Testing
- npm run build

