### PR TITLE
Force dynamic rendering for calendar page

### DIFF
--- a/app/calendario/page.tsx
+++ b/app/calendario/page.tsx
@@ -1,5 +1,7 @@
 import { getCalendarContent } from "@/lib/data/content";
 
+export const dynamic = "force-dynamic";
+
 export default async function CalendarioPage() {
   const { events, monthTitle, modeLabel, summary, ctaLabel } = await getCalendarContent();
   const days = Array.from({ length: 31 }, (_, index) => index + 1);

--- a/components/diagrams/architecture-diagram.tsx
+++ b/components/diagrams/architecture-diagram.tsx
@@ -243,7 +243,6 @@ function createNode({ name, color, accent, position, inPorts = [], outPorts = []
 
 export function ArchitectureDiagram() {
   const buildModel = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (engine: DiagramEngine) => {
       const factory = new ArchitectureNodeFactory();
       factory.setDiagramEngine(engine);

--- a/components/diagrams/bpmn-diagram.tsx
+++ b/components/diagrams/bpmn-diagram.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback } from "react";
-import type { ReactElement } from "react";
 import { DiagramModel, DefaultLinkModel, type DiagramEngine } from "@projectstorm/react-diagrams";
 import { AbstractReactFactory } from "@projectstorm/react-canvas-core";
 import { NodeModel, PortModel, PortModelAlignment, PortWidget } from "@projectstorm/react-diagrams-core";

--- a/lib/data/content.ts
+++ b/lib/data/content.ts
@@ -217,26 +217,32 @@ const journeyContent: JourneyContent = {
   ],
 };
 
-const calendarContent: CalendarContent = {
-  events: [
-    { title: "Reunión con aerolínea", day: 3, color: "border-sky-400/50 bg-sky-500/15" },
-    { title: "Entrega cotizaciones grupales", day: 9, color: "border-emerald-400/40 bg-emerald-500/15" },
-    { title: "Capacitación agentes", day: 17, color: "border-indigo-400/40 bg-indigo-500/15" },
-    { title: "Cierre KPI mensual", day: 28, color: "border-amber-400/40 bg-amber-500/15" },
-  ],
-  monthTitle: "Octubre 2024",
-  modeLabel: "Modo colaborativo",
-  summary:
-    "Consolida hitos comerciales, capacitaciones y entregables críticos para coordinar la atención en WhatsApp.",
-  ctaLabel: "Crear nuevo evento",
-};
+function createCalendarContent(): CalendarContent {
+  const now = new Date();
+  const monthName = new Intl.DateTimeFormat("es-ES", { month: "long" }).format(now);
+  const capitalizedMonth = monthName.charAt(0).toUpperCase() + monthName.slice(1);
+
+  return {
+    events: [
+      { title: "Reunión con aerolínea", day: 3, color: "border-sky-400/50 bg-sky-500/15" },
+      { title: "Entrega cotizaciones grupales", day: 9, color: "border-emerald-400/40 bg-emerald-500/15" },
+      { title: "Capacitación agentes", day: 17, color: "border-indigo-400/40 bg-indigo-500/15" },
+      { title: "Cierre KPI mensual", day: 28, color: "border-amber-400/40 bg-amber-500/15" },
+    ],
+    monthTitle: `${capitalizedMonth} ${now.getFullYear()}`,
+    modeLabel: "Modo colaborativo",
+    summary:
+      "Consolida hitos comerciales, capacitaciones y entregables críticos para coordinar la atención en WhatsApp.",
+    ctaLabel: "Crear nuevo evento",
+  };
+}
 
 const contentLoaders = {
   home: async () => homeContent,
   journey: async () => journeyContent,
   bpmn: async () => bpmnContent,
   arquitectura: async () => architectureContent,
-  calendario: async () => calendarContent,
+  calendario: async () => createCalendarContent(),
 };
 
 export async function getHomeContent(): Promise<HomeContent> {


### PR DESCRIPTION
## Summary
- mark the calendario route as force-dynamic so the month title updates on every request
- clean up unused lint overrides and imports left over from earlier diagram work

## Testing
- npm run lint

